### PR TITLE
skipSnapshots parameter added

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ attached to the *deploy* phase.  This will occur after any packaging type's depl
 
 The supported parameters are:
 
-| Parameter | Required | Property | Default | Description |
-|-----------|----------|----------|---------|-------------|
-|skip       | No       |git.skip  |false    |Skip executing the plugin |
-|tagName    | Yes      |git.tagName|         |Tag name     |
-|message    | No       |git.message|release ${tagName}|Tag message|
-|branch     | No       |git.branch|HEAD     |Tag at head of this branch|
-|remote     | No       |git.remote|origin   |Remote repository to push tag to|
-|useDotSsh  | No       |git.use.ssh|false   |Use the contents of ~/.ssh instead of ~/.m2/settings.xml to configure ssh connections|
-|skipPush   | No       |git.skipPush|false  |Skip pushing the tag to remote|
+|   Parameter    | Required |    Property     | Default | Description |
+|----------------|----------|-----------------|---------|-------------|
+|skip            | No       |git.skip         |false    |Skip executing the plugin |
+|tagName         | Yes      |git.tagName      |         |Tag name     |
+|message         | No       |git.message      |release ${tagName}|Tag message|
+|branch          | No       |git.branch       |HEAD     |Tag at head of this branch|
+|remote          | No       |git.remote       |origin   |Remote repository to push tag to|
+|useDotSsh       | No       |git.use.ssh      |false    |Use the contents of ~/.ssh instead of ~/.m2/settings.xml to configure ssh connections|
+|skipPush        | No       |git.skipPush     |false    |Skip pushing the tag to remote|
+|skipSnapshots   | No       |git.skipSnapshots|true     |Skip creating tag for snapshots|
 
 ### Typical attached phase use:
 
@@ -42,7 +43,7 @@ The supported parameters are:
       <plugin>
         <groupId>org.honton.chas</groupId>
         <artifactId>git-tag-maven-plugin</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4-SNAPSHOT</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/org/honton/chas/maven/git/TagGit.java
+++ b/src/main/java/org/honton/chas/maven/git/TagGit.java
@@ -38,6 +38,7 @@ class TagGit {
     String tagName;
     String message;
     boolean skipPush;
+    boolean skipSnapshots;
     boolean useUseDotSsh;
   }
 
@@ -51,6 +52,12 @@ class TagGit {
     throws IOException, GitAPIException {
     this.log = log;
     this.servers = servers;
+
+    if (cfg.getTagName().endsWith("SNAPSHOT") && cfg.isSkipSnapshots()) {
+        log.info("Tagname '" + cfg.getTagName() + "' is recognized as SNAPSHOT and skipSnapshots is set to true. Tagging not evaluated");
+        return;
+    }
+
     serverAccess = new Function<String, Server>() {
       @Override
       public Server apply(final String id) {

--- a/src/main/java/org/honton/chas/maven/git/TagGitMojo.java
+++ b/src/main/java/org/honton/chas/maven/git/TagGitMojo.java
@@ -77,6 +77,12 @@ public class TagGitMojo extends AbstractMojo {
   private boolean skipPush;
 
   /**
+   * Skip creating tag for SNAPSHOTs.
+   */
+  @Parameter(defaultValue = "true", property = "git.skipSnapshots")
+  private boolean skipSnapshots;
+
+  /**
    * Use the contents of the ~/.ssh directory instead of ~/.m2/settings.xml to configure ssh
    * connections.
    */
@@ -121,7 +127,7 @@ public class TagGitMojo extends AbstractMojo {
       return null;
     } else {
       File gitDir = new FileRepositoryBuilder().findGitDir(baseDir).getGitDir();
-      return new TagGit.Configuration(gitDir, branch, remote, tagName, message, skipPush, useUseDotSsh);
+      return new TagGit.Configuration(gitDir, branch, remote, tagName, message, skipPush, skipSnapshots, useUseDotSsh);
     }
   }
 


### PR DESCRIPTION
Added new configuration parameter skipSnapshots. This parameter has default value true and cancels creating tag in case of tagName ends with 'SNAPSHOT'